### PR TITLE
Implement node public flag and host-node links

### DIFF
--- a/app/dashboard/build/statics/locales/en.json
+++ b/app/dashboard/build/statics/locales/en.json
@@ -92,6 +92,7 @@
   "memoryUsage": "memory usage",
   "next": "Next",
   "nodes.addHostForEveryInbound": "Add this node as a new host for every inbound",
+  "nodes.publicNode": "Public node",
   "nodes.addNewMarzbanNode": "Add New Marzban Node",
   "nodes.addNode": "Add Node",
   "nodes.addNodeSuccess": "Node {{name}} added successfully",

--- a/app/dashboard/build/statics/locales/fa.json
+++ b/app/dashboard/build/statics/locales/fa.json
@@ -98,6 +98,7 @@
   "memoryUsage": "مصرف حافظه",
   "next": "بعدی",
   "nodes.addHostForEveryInbound": "استفاده از این گره به عنوان میزبان تمام ورودی‌ها",
+  "nodes.publicNode": "گره عمومی",
   "nodes.addNewMarzbanNode": "افزودن گره مرزبان",
   "nodes.addNode": "افزودن گره",
   "nodes.addNodeSuccess": "گره {{name}} با موفقیت افزوده شد",

--- a/app/dashboard/build/statics/locales/ru.json
+++ b/app/dashboard/build/statics/locales/ru.json
@@ -92,6 +92,7 @@
   "memoryUsage": "Память",
   "next": "Вперед",
   "nodes.addHostForEveryInbound": "Добавить этот узел, как новый хост для каждого inbound",
+  "nodes.publicNode": "Публичный узел",
   "nodes.addNewMarzbanNode": "Добавить новый узел Marzban",
   "nodes.addNode": "Добавить узел",
   "nodes.addNodeSuccess": "Узел {{name}} успешно добавлен",

--- a/app/dashboard/build/statics/locales/zh.json
+++ b/app/dashboard/build/statics/locales/zh.json
@@ -92,6 +92,7 @@
   "memoryUsage": "内存状态",
   "next": "下一页",
   "nodes.addHostForEveryInbound": "为每个入站请求添加此节点作为新主机",
+  "nodes.publicNode": "公共节点",
   "nodes.addNewMarzbanNode": "添加新的 Marzban 节点",
   "nodes.addNode": "添加节点",
   "nodes.addNodeSuccess": "节点 {{name}} 添加成功",

--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -95,6 +95,7 @@
   "memoryUsage": "memory usage",
   "next": "Next",
   "nodes.addHostForEveryInbound": "Add this node as a new host for every inbound",
+  "nodes.publicNode": "Public node",
   "nodes.addNewMarzbanNode": "Add New Marzban Node",
   "nodes.addNode": "Add Node",
   "nodes.addNodeSuccess": "Node {{name}} added successfully",

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -99,6 +99,7 @@
   "memoryUsage": "مصرف حافظه",
   "next": "بعدی",
   "nodes.addHostForEveryInbound": "استفاده از این گره به عنوان میزبان تمام ورودی‌ها",
+  "nodes.publicNode": "گره عمومی",
   "nodes.addNewMarzbanNode": "افزودن گره مرزبان",
   "nodes.addNode": "افزودن گره",
   "nodes.addNodeSuccess": "گره {{name}} با موفقیت افزوده شد",

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -93,6 +93,7 @@
   "memoryUsage": "Память",
   "next": "Вперед",
   "nodes.addHostForEveryInbound": "Добавить этот узел, как новый хост для каждого inbound",
+  "nodes.publicNode": "Публичный узел",
   "nodes.addNewMarzbanNode": "Добавить новый узел Marzban",
   "nodes.addNode": "Добавить узел",
   "nodes.addNodeSuccess": "Узел {{name}} успешно добавлен",

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -93,6 +93,7 @@
   "memoryUsage": "内存状态",
   "next": "下一页",
   "nodes.addHostForEveryInbound": "为每个入站请求添加此节点作为新主机",
+  "nodes.publicNode": "公共节点",
   "nodes.addNewMarzbanNode": "添加新的 Marzban 节点",
   "nodes.addNode": "添加节点",
   "nodes.addNodeSuccess": "节点 {{name}} 添加成功",

--- a/app/dashboard/src/components/NodesModal.tsx
+++ b/app/dashboard/src/components/NodesModal.tsx
@@ -517,6 +517,10 @@ const NodeForm: NodeFormType = ({
             </Checkbox>
           </FormControl>
         )}
+        <FormControl py={1} display="flex" alignItems="center">
+          <Switch id="is_public" {...form.register("is_public")}/>
+          <FormLabel htmlFor="is_public" mb={0} ml={2}>{t("nodes.publicNode")}</FormLabel>
+        </FormControl>
         <HStack w="full">
           {btnLeftAdornment}
           <Button

--- a/app/dashboard/src/contexts/NodesContext.tsx
+++ b/app/dashboard/src/contexts/NodesContext.tsx
@@ -24,6 +24,7 @@ export const NodeSchema = z.object({
   message: z.string().nullable().optional(),
   add_as_new_host: z.boolean().optional(),
   usage_coefficient: z.number().or(z.string().transform((v) => parseFloat(v))),
+  is_public: z.boolean().optional(),
 });
 
 export type NodeType = z.infer<typeof NodeSchema>;
@@ -35,6 +36,7 @@ export const getNodeDefaultValues = (): NodeType => ({
   api_port: 62051,
   xray_version: "",
   usage_coefficient: 1,
+  is_public: true,
 });
 
 export const FetchNodesQueryKey = "fetch-nodes-query-key";

--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -95,7 +95,7 @@ def get_hosts(db: Session, inbound_tag: str) -> List[ProxyHost]:
     return inbound.hosts
 
 
-def add_host(db: Session, inbound_tag: str, host: ProxyHostModify) -> List[ProxyHost]:
+def add_host(db: Session, inbound_tag: str, host: ProxyHostModify, node_id: int | None = None) -> List[ProxyHost]:
     """
     Adds a new host to a proxy inbound.
 
@@ -119,7 +119,8 @@ def add_host(db: Session, inbound_tag: str, host: ProxyHostModify) -> List[Proxy
             inbound=inbound,
             security=host.security,
             alpn=host.alpn,
-            fingerprint=host.fingerprint
+            fingerprint=host.fingerprint,
+            node_id=node_id
         )
     )
     db.commit()
@@ -127,7 +128,7 @@ def add_host(db: Session, inbound_tag: str, host: ProxyHostModify) -> List[Proxy
     return inbound.hosts
 
 
-def update_hosts(db: Session, inbound_tag: str, modified_hosts: List[ProxyHostModify]) -> List[ProxyHost]:
+def update_hosts(db: Session, inbound_tag: str, modified_hosts: List[ProxyHostModify], node_id: int | None = None) -> List[ProxyHost]:
     """
     Updates hosts for a given inbound tag.
 
@@ -159,6 +160,7 @@ def update_hosts(db: Session, inbound_tag: str, modified_hosts: List[ProxyHostMo
             noise_setting=host.noise_setting,
             random_user_agent=host.random_user_agent,
             use_sni_as_host=host.use_sni_as_host,
+            node_id=node_id,
         ) for host in modified_hosts
     ]
     db.commit()
@@ -1330,7 +1332,8 @@ def create_node(db: Session, node: NodeCreate) -> Node:
     dbnode = Node(name=node.name,
                   address=node.address,
                   port=node.port,
-                  api_port=node.api_port)
+                  api_port=node.api_port,
+                  is_public=node.is_public)
 
     db.add(dbnode)
     db.commit()
@@ -1387,6 +1390,9 @@ def update_node(db: Session, dbnode: Node, modify: NodeModify) -> Node:
 
     if modify.usage_coefficient:
         dbnode.usage_coefficient = modify.usage_coefficient
+
+    if modify.is_public is not None:
+        dbnode.is_public = modify.is_public
 
     db.commit()
     db.refresh(dbnode)

--- a/app/db/migrations/versions/d5e7c2742b95_add_is_public_and_node_id.py
+++ b/app/db/migrations/versions/d5e7c2742b95_add_is_public_and_node_id.py
@@ -1,0 +1,25 @@
+"""add is_public to nodes and node_id to hosts
+
+Revision ID: d5e7c2742b95
+Revises: add_custom_subscription_fields
+Create Date: 2025-06-01 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'd5e7c2742b95'
+down_revision = 'add_custom_subscription_fields'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.add_column('nodes', sa.Column('is_public', sa.Boolean(), nullable=False, server_default=sa.text('1')))
+    op.add_column('hosts', sa.Column('node_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(None, 'hosts', 'nodes', ['node_id'], ['id'])
+
+
+def downgrade() -> None:
+    op.drop_constraint(None, 'hosts', type_='foreignkey')
+    op.drop_column('hosts', 'node_id')
+    op.drop_column('nodes', 'is_public')

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -259,6 +259,8 @@ class ProxyHost(Base):
         server_default=ProxyHostSecurity.none.name
     )
 
+    node_id = Column(Integer, ForeignKey("nodes.id"), nullable=True)
+
     inbound_tag = Column(String(256), ForeignKey("inbounds.tag"), nullable=False)
     inbound = relationship("ProxyInbound", back_populates="hosts")
     allowinsecure = Column(Boolean, nullable=True)
@@ -308,6 +310,7 @@ class Node(Base):
     last_status_change = Column(DateTime, default=datetime.utcnow)
     message = Column(String(1024), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
+    is_public = Column(Boolean, nullable=False, default=True, server_default='1')
     uplink = Column(BigInteger, default=0)
     downlink = Column(BigInteger, default=0)
     user_usages = relationship("NodeUserUsage", back_populates="node", cascade="all, delete-orphan")

--- a/app/models/node.py
+++ b/app/models/node.py
@@ -21,6 +21,7 @@ class Node(BaseModel):
     address: str
     port: int = 62050
     api_port: int = 62051
+    is_public: bool = True
     usage_coefficient: float = Field(gt=0, default=1.0)
 
 
@@ -33,7 +34,8 @@ class NodeCreate(Node):
             "port": 62050,
             "api_port": 62051,
             "add_as_new_host": True,
-            "usage_coefficient": 1
+            "usage_coefficient": 1,
+            "is_public": True
         }
     })
 
@@ -45,6 +47,7 @@ class NodeModify(Node):
     api_port: Optional[int] = Field(None, nullable=True)
     status: Optional[NodeStatus] = Field(None, nullable=True)
     usage_coefficient: Optional[float] = Field(None, nullable=True)
+    is_public: Optional[bool] = Field(None, nullable=True)
     model_config = ConfigDict(json_schema_extra={
         "example": {
             "name": "DE node",
@@ -52,7 +55,8 @@ class NodeModify(Node):
             "port": 62050,
             "api_port": 62051,
             "status": "disabled",
-            "usage_coefficient": 1.0
+            "usage_coefficient": 1.0,
+            "is_public": True
         }
     })
 

--- a/app/routers/node.py
+++ b/app/routers/node.py
@@ -26,7 +26,7 @@ router = APIRouter(
 )
 
 
-def add_host_if_needed(new_node: NodeCreate, db: Session):
+def add_host_if_needed(new_node: NodeCreate, node_id: int, db: Session):
     """Add a host if specified in the new node settings."""
     if new_node.add_as_new_host:
         host = ProxyHost(
@@ -34,7 +34,7 @@ def add_host_if_needed(new_node: NodeCreate, db: Session):
             address=new_node.address,
         )
         for inbound_tag in xray.config.inbounds_by_tag:
-            crud.add_host(db, inbound_tag, host)
+            crud.add_host(db, inbound_tag, host, node_id=node_id)
         xray.hosts.update()
 
 
@@ -64,7 +64,7 @@ def add_node(
         )
 
     bg.add_task(xray.operations.connect_node, node_id=dbnode.id)
-    bg.add_task(add_host_if_needed, new_node, db)
+    bg.add_task(add_host_if_needed, new_node, dbnode.id, db)
 
     logger.info(f'New node "{dbnode.name}" added')
     return dbnode


### PR DESCRIPTION
## Summary
- link hosts to nodes and mark nodes public/private
- expose `is_public` to frontend API and UI
- allow dashboard to set node visibility
- migration for new `nodes.is_public` and `hosts.node_id` columns

## Testing
- `python -m py_compile app/db/models.py app/models/node.py app/db/crud.py app/routers/node.py`

------
https://chatgpt.com/codex/tasks/task_e_683fef262b5c8332be76f7660838ead6